### PR TITLE
Improved Entropy Collection

### DIFF
--- a/src/pages/entropyInput.tsx
+++ b/src/pages/entropyInput.tsx
@@ -39,7 +39,7 @@ const EntropyInputPage = () => {
   )
   const handleSubmit = () => {
     if (percentage !== 100) return
-    saveGeneratedEntropy()
+    processGeneratedEntropy()
     if (provider === 'Ethereum') {
       navigate(ROUTES.DOUBLE_SIGN)
     } else {
@@ -56,7 +56,7 @@ const EntropyInputPage = () => {
     )
   }
 
-  const saveGeneratedEntropy = async () => {
+  const processGeneratedEntropy = async () => {
     const entropy = mouseEntropy + keyEntropy + randomBytes(32);
     const entropyAsArray = Uint8Array.from(entropy.split("").map(x => x.charCodeAt(0)))
     /*

--- a/src/pages/entropyInput.tsx
+++ b/src/pages/entropyInput.tsx
@@ -32,6 +32,7 @@ const EntropyInputPage = () => {
   const [keyEntropy, setKeyEntropy] = useState('')
   const [mouseEntropy, setMouseEntropy] = useState('')
   const [lastMouseEntropyUpdate, setLastMouseEntropyUpdate] = useState(0)
+  const [mouseEntropyRandomOffset, setMouseEntropyRandomOffset] = useState(0)
   const [mouseEntropySamples, setMouseEntropySamples] = useState(0)
   const [percentage, setPercentage] = useState(0)
   const [player, setPlayer] = useState<Player | null>(null)
@@ -58,9 +59,9 @@ const EntropyInputPage = () => {
     from ~ U[0, 255] to increase sample periodicity variance.
     performance.now() is used for timestamps due to its sub-millisecond resolution in some browsers.
     */
-   const randOffset = randomBytes(1)[0]
-    if (performance.now() - lastMouseEntropyUpdate > randOffset) {
+    if (performance.now() - lastMouseEntropyUpdate > mouseEntropyRandomOffset) {
       setLastMouseEntropyUpdate(performance.now())
+      setMouseEntropyRandomOffset(randomBytes(1)[0])
       setMouseEntropySamples(mouseEntropySamples + 1)
       setMouseEntropy(`${mouseEntropy}${e.movementX}${e.movementY}${e.screenX}${e.screenY}${performance.now()}`)
     }

--- a/src/pages/entropyInput.tsx
+++ b/src/pages/entropyInput.tsx
@@ -1,4 +1,4 @@
-import { useState, MouseEventHandler, useEffect } from 'react'
+import { useState, MouseEventHandler, useEffect, ChangeEventHandler } from 'react'
 import styled from 'styled-components'
 import { useNavigate } from 'react-router-dom'
 import { PrimaryButton } from '../components/Button'
@@ -65,6 +65,10 @@ const EntropyInputPage = () => {
     }
   }
 
+  const handleCaptureKeyEntropy: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setKeyEntropy(`${keyEntropy}${e.target.value}${performance.now()}`)
+  }
+
   const processGeneratedEntropy = async () => {
     const entropy = mouseEntropy + keyEntropy + randomBytes(32);
     const entropyAsArray = Uint8Array.from(entropy.split("").map(x => x.charCodeAt(0)))
@@ -121,7 +125,7 @@ const EntropyInputPage = () => {
           </TextSection>
           <Input
             placeholder="Secret"
-            onChange={(e) => setKeyEntropy(e.target.value)}
+            onChange={handleCaptureKeyEntropy}
           />
 
           <ButtonSection>


### PR DESCRIPTION
This PR aims to harden the Entropy collection process via the flowing steps:

- Collect a fixed number (64) of mouse events
- Only collect a mouse event every 128 ms. (Sampled from $X \sim U[0, 255]$ ms.) (Note that this means the expected minimum mouse entropy collection time is 64 * 128ms = 8.2s)
- Rename `saveGeneratedEntropy` -> `processGeneratedEntropy`
- Mixes timestamps into Keyboard entropy collection (in addition to actual text)
- Mixes in actual CSPRNG randomness into the final entropy (not exclusively via the `salt` as technically `salt`s are public)


__Please note:__ This PR needs heavy review, I am not a JS dev.