### PR TITLE
Trim address using css with ellipsis, hide on mobile

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -39,12 +39,10 @@ const Header = () => {
         </SequencerStatus>
       </LeftSection>
       <RightSection>
-        <div>
-          {nickname ? (<span>{nickname.slice(0, 10)}</span>) : ("")}
-        </div>
-        <div>
-          <LanguageSelector />
-        </div>
+        <Address>
+          {nickname}
+        </Address>
+        <LanguageSelector />
       </RightSection>
     </Container>
   )
@@ -105,6 +103,16 @@ const Indicator = styled(Star)<{ isOnline: boolean; color: string }>`
   color: black;
   @media (max-width: ${BREAKPOINT.S}) {
     color: ${({ color }) => color};
+  }
+`
+
+const Address = styled.div`
+  max-width: 11ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  @media (max-width: ${BREAKPOINT.M}) {
+    display: none;
   }
 `
 


### PR DESCRIPTION
### Description
- Removes `.slice()` and instead gives a max character width using css, and shows an ellipsis for overflow
- Hides address from nav bar on mobile

<img width="348" alt="image" src="https://user-images.githubusercontent.com/54227730/201422530-ea114cc1-c45f-485a-a752-3e02cc6254e2.png">
