### PR TITLE
Hide language name on mobile screen sizes

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -95,8 +95,7 @@ const Status = styled.span<{ color: string }>`
 const RightSection = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  shape-outside: circle();
+  gap: 1rem;
 `
 
 const Indicator = styled(Star)<{ isOnline: boolean; color: string }>`

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 
 import TranslatorImg from '../assets/translator.svg'
 
-import { FONT_SIZE } from '../constants'
+import { BREAKPOINT, FONT_SIZE } from '../constants'
 import { locales } from '../locales'
 
 const LanguageSelector = () => {
@@ -77,7 +77,12 @@ const LanguageSelector = () => {
 const Container = styled.div`
   display: flex;
   align-items: center;
-  margin-left: 10px;
+  width: fit-content;
+  div[class*=singleValue] {
+    @media (max-width: ${BREAKPOINT.S}) {
+      display: none;
+    }
+  }
 `
 
 export default LanguageSelector

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -77,12 +77,15 @@ const LanguageSelector = () => {
 const Container = styled.div`
   display: flex;
   align-items: center;
-  width: fit-content;
-  div[class*=singleValue] {
+  div {
+    width: fit-content;
+  }
+  [class*=ValueContainer] {
     @media (max-width: ${BREAKPOINT.S}) {
       display: none;
     }
   }
+
 `
 
 export default LanguageSelector


### PR DESCRIPTION
## Description
As one possible option for handling the Header contents on mobile, this PR hides the actual name of the language on mobile-sized screens. 

<img width="460" alt="image" src="https://user-images.githubusercontent.com/54227730/201423109-cc47c35a-3db9-42f2-a89e-fce754684f11.png">

## Related issue
- #58 