### PR TITLE
Finalize copy

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -19,7 +19,7 @@ const LanguageSelector = () => {
   const getOptions = () => {
     const options = Object.keys(locales).map((language) => ({
       value: language,
-      label: t(language, { lng: 'en' })
+      label: t(`language.${language}`, { lng: language })
     }))
     return options
   }
@@ -68,7 +68,7 @@ const LanguageSelector = () => {
         styles={selectStyles}
         options={getOptions()}
         onChange={handleChange}
-        defaultValue={{ value: 'en', label: t('en', { lng: 'en' }) }}
+        defaultValue={{ value: 'en', label: t('language.en', { lng: 'en' }) }}
       />
     </Container>
   )

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,27 +1,25 @@
 {
   "translation": {
-    "es": "Spanish",
-    "en": "English",
     "complete": {
       "button": "View your contribution",
       "description": "<0>Success! Echoes of you are permanently fused with the others in this Summoning Ceremony.</0>",
-      "title": "Dankshard <br/> draws near",
       "modal": {
-        "keys": "MY KEYS",
-        "timestamp": "Contribution completed at:",
         "acknowledgment": "SEQUENCER ACKNOWLEDGEMENT",
-        "receipt": "Contribution receipt:",
-        "signedBy": "Signed by ",
-        "integrityChecks": "Integrity checks ",
-        "shareTwitter": "Share on Twitter",
-        "tweet": "I just contributed to the KZG Ceremony to scale Ethereum using {{identity}}. You can do it too in https://ceremony.ethereum.org @ethereum #KZGCeremony",
         "checks": {
-          "failedWitness": "Witness does not match PoT pubkeys",
           "failedComputeSignature": "Signature was not processed correctly",
           "failedSignature": "Sequencer signature does not contain sequencer address",
+          "failedWitness": "Witness does not match PoT pubkeys",
           "success": "Passed"
-        }
-      }
+        },
+        "integrityChecks": "Integrity checks ",
+        "keys": "MY KEYS",
+        "receipt": "Contribution receipt:",
+        "shareTwitter": "Share on Twitter",
+        "signedBy": "Signed by ",
+        "timestamp": "Contribution completed at:",
+        "tweet": "I just contributed to the KZG Ceremony to scale Ethereum using {{identity}}. You can do it too in https://ceremony.ethereum.org @ethereum #KZGCeremony"
+      },
+      "title": "Dankshard <br/> draws near"
     },
     "contributing": {
       "button": "View my contribution",
@@ -31,8 +29,8 @@
         "error": "There was an error {{error}}. Reload and try again"
       },
       "title": {
-        "contributing": "You have been<br/>called upon<br/>Now",
         "completed": "Contribution<br/>Complete",
+        "contributing": "You have been<br/>called upon<br/>Now",
         "error": "Something<br/>Went<br/>Wrong"
       }
     },
@@ -53,7 +51,7 @@
     },
     "faq": {
       "q1": {
-        "content": "<0>The Ethereum community is scaling to global accessibility through <2>Layer-2s (L2s)</2>. L2s increase the total blockspace available to users while still maintaining the security offered by the Ethereum Layer 1 (L1).</0><1>L2s need to publish a lot of data on Ethereum, and the network currently charges high fees for doing so. To fix this, Ethereum will create a new data layer, often referred to as <1>sharding</1>. This provides what is called \"data availability\" guarantees to L2 users. The L1 only holds the data for a limited time, which means we can scale the chain without sacrificing decentralization for smaller L1 node operators.</1><2>The current leading design for this is called Danksharding. The rollout for this will happen in several steps, with the first one being <2>EIP-4844</2>, also known as ProtoDanksharding. </2>",
+        "content": "<0>The Ethereum community is scaling to global accessibility through <2>Layer-2s (L2s)</2>. L2s increase the total block space available to users while still maintaining the security offered by the Ethereum Layer 1 (L1).</0><1>L2s need to publish a lot of data on Ethereum, and the network currently charges high fees for doing so. To fix this, Ethereum will create a new data layer, often referred to as <1>sharding</1>. This provides what is called \"data availability\" guarantees to L2 users. The L1 only holds the data for a limited time, which means we can scale the chain without sacrificing decentralization for smaller L1 node operators.</1><2>The current leading design for this is called Danksharding. The rollout for this will happen in several steps, with the first one being <2>EIP-4844</2>, also known as ProtoDanksharding. </2>",
         "title": "What is EIP-4844, a.k.a. Proto-Danksharding, and how does it relate to scaling Ethereum"
       },
       "q10": {
@@ -101,7 +99,7 @@
         "title": "What does KZG stand for?"
       },
       "q6": {
-        "content": "<p>This interface will walk you through the following steps:</p><1><0>Log in with Ethereum or Github to prevent spam.</0><1>You provide random inputs from three different sources.</1><2>Ask the Sequencer if you may participate. When it's your turn, the Sequencer will send you the \"Powers of Tau\" data.</2><3>Your computer will mix your randomness into the Powers of Tau and when completed, send it back to the Sequencer.</3><4>The Sequencer will verify that your computer did everything correctly and pass the Powers of Tau on to the next participant.</4></1><p>After the ceremony is completed, you should return to verify that your contribution was indeed included in the final transcript.</p>",
+        "content": "<p>This interface will walk you through the following steps:</p><1><0>You provide random inputs from three different sources.</0><1>Log in with Ethereum or Github to prevent spam.</1><2>Ask the Sequencer if you may participate. When it's your turn, the Sequencer will send you the \"Powers of Tau\" data.</2><3>Your computer will mix your randomness into the Powers of Tau and when completed, send it back to the Sequencer.</3><4>The Sequencer will verify that your computer did everything correctly and pass the Powers of Tau on to the next participant.</4></1><p>After the ceremony is completed, you should return to verify that your contribution was indeed included in the final transcript.</p>",
         "title": "What happens during this Ceremony?"
       },
       "q7": {
@@ -123,7 +121,7 @@
       "documentation": "Documentation",
       "faq": "FAQ"
     },
-      "header": {
+    "header": {
       "offline": "Offline",
       "online": "Online",
       "sequencer": "Sequencer"
@@ -135,6 +133,19 @@
       "learn-more": "↓ or learn more below ↓",
       "learn-more-mobile": "↓ learn more below ↓",
       "title": "SUMMONING <br/> GUIDE"
+    },
+    "language": {
+      "de": "German",
+      "es": "Spanish",
+      "en": "English",
+      "fr": "French",
+      "hi": "Hindi",
+      "id": "Indonesian",
+      "ja": "Japanese",
+      "ko": "Korean",
+      "ro": "Romanian",
+      "ru": "Russian",
+      "zh": "Chinese"
     },
     "lobby": {
       "description": "<0>Your contribution is ready to be accepted by the Sequencer. Please leave this guide open in the background and we will add your contribution to the others soon.</0><1>Please leave this guide open and awake.</1>",
@@ -175,7 +186,7 @@
     },
     "error": {
       "notSameWallet": "Use the same wallet you used to signing with Ethereum",
-      "pastSubgroupChecksFailed": "Subgroup check failed in the contribution you received. Please report it inmmediately",
+      "pastSubgroupChecksFailed": "Subgroup check failed in the contribution you received. Please report it immediately",
       "newSubgroupChecksFailed": "Subgroup check failed in your computed contribution. Please check your setup and try again",
       "tryContributeError": {
         "rateLimited": "Your call to the sequencer came too early. Remember that there is a specific time interval between calls",
@@ -188,7 +199,7 @@
         "invalidAuthCode": "The web application is using an invalid authorization code. Please report it on Github",
         "fetchUserDataError": "The sequencer could not get user data from the authorization service. Please report it on Github",
         "couldNotExtractUserData": "The sequencer could not extract user data from the authorization service. Please report it on Github",
-        "userCreatedAfterDeadline": "Your wallet does not have the minimum transaction quantity to pass our antisybil tests.",
+        "userCreatedAfterDeadline": "Your wallet does not have the minimum transaction quantity to pass our anti-Sybil tests.",
         "customError": "There has been an unknown error: {{error}}"
       },
       "contributeError": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -26,8 +26,8 @@
     "contributing": {
       "button": "View my contribution",
       "description": {
+        "completed": "<0>You have just successfully complete the contribution. Don’t forget to return for the summoning ending & spread the words.</0>",
         "contributing": "<0>You are now entrusted with the Powers of Tau. Your Secret, Sigil, and Sample are being fused with those that came before.</0><1>Rituals cannot be hastened - time given here creates timeless artifacts.</1>",
-        "completed": "<0>You have just succesfully complete the contribution. Don’t forget to return for the summoning ending & spread the words.</0>",
         "error": "There was an error {{error}}. Reload and try again"
       },
       "title": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1,7 +1,9 @@
 {
   "translation": {
-    "es": "Español",
-    "en": "Inglés",
+    "language": {
+      "es": "Español",
+      "en": "Inglés"
+    },
     "header": { "sequencer": "Sequenciador" },
     "complete": {
       "title": "Dankshard <br/> está cerca",

--- a/src/pages/contributing.tsx
+++ b/src/pages/contributing.tsx
@@ -158,7 +158,7 @@ const ContributingPage = () => {
                   ) : step === 'completed' ? (
                     <Trans i18nKey="contributing.description.completed">
                       <Description>
-                        You have just succesfully complete the contribution. Don’t
+                        You have just successfully complete the contribution. Don’t
                         forget to return for the summoning ending & spread the
                         words.
                       </Description>

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -29,7 +29,7 @@ const faqQuestions = [
           <ExternalLink href="https://ethereum.org/en/layer-2/">
             Layer-2s (L2s)
           </ExternalLink>
-          . L2s increase the total blockspace available to users while still
+          . L2s increase the total block space available to users while still
           maintaining the security offered by the Ethereum Layer 1 (L1).
         </p>
         <p>


### PR DESCRIPTION
- Fixes a couple typos
- Pulls language names into translation file, nesting under `language` key
- Switch language picking menu to display native language form of lang name (ie, "English", "Español", instead of "English" "Spanish")
- Updates json with latest copy from `yarn extract`