### PR TITLE
Lookup ENS names for Latest Contributors

### DIFF
--- a/src/components/RecordTable.tsx
+++ b/src/components/RecordTable.tsx
@@ -56,7 +56,7 @@ const RecordTable = ({
         <Row key={record.position} onClick={() => setSelectedTranscriptItem(record)}>
           <Col>{record.position}</Col>
           <Col flex={4} width="0">
-            <Address>{record.participantId}</Address>
+            <Address>{record.participantName ?? record.participantId}</Address>
           </Col>
           <Col center>
             {record.transcripts.map((transcript, i) => (

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export type SubTranscript = {
 export type Record = {
   position: number
   participantId: string | null
+  participantName?: string | null
   participantEcdsaSignature: string | null
   transcripts: TranscriptDetails[]
 }


### PR DESCRIPTION
Uses the existing INFURA_ID to lookup ENS names in the table of latest contributions, and sets a new `participantName` optional property. Fails silently with a console.error if the lookup fails.

![Screenshot from 2023-01-12 12-44-54](https://user-images.githubusercontent.com/429604/212113291-2d4d84f7-41b3-48dd-9e03-485e6d173902.png)
