### PR TITLE
Update intl URL support

### DIFF
--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,6 +1,6 @@
 import TranslatorImg from '../assets/translator.svg'
 import { useLanguageStore } from '../store/language'
-import { BREAKPOINT, FONT_SIZE } from '../constants'
+import { BREAKPOINT, FONT_SIZE, LANG_QUERY_PARAM } from '../constants'
 import Select, { StylesConfig } from 'react-select'
 import { useTranslation } from 'react-i18next'
 import styled from 'styled-components'
@@ -16,6 +16,10 @@ const LanguageSelector = () => {
   const handleChange = (event: any) => {
     i18n.changeLanguage(event.value)
     updateSelectedLanguage(event.value)
+
+    const searchParams = new URLSearchParams(window.location.search)
+    searchParams.set(LANG_QUERY_PARAM, event.value)
+    window.history.replaceState({}, '', `${window.location.pathname}?${searchParams.toString()}`)
   }
 
   const MAIN_COLOR = 'black'
@@ -28,7 +32,7 @@ const LanguageSelector = () => {
     return options
   }
 
-  const selectedLanguageToUse = selectedLanguage || 'en'
+  const selectedLanguageToUse = (new URLSearchParams(window.location.search)).get(LANG_QUERY_PARAM) ?? selectedLanguage ?? 'en'
 
   useEffect(() => {
     if (selectedLanguage){

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -13,13 +13,16 @@ const LanguageSelector = () => {
   const { i18n, t } = useTranslation()
   const { selectedLanguage, updateSelectedLanguage } = useLanguageStore()
 
+  const setLangQueryParam = (language: string) => {
+    const searchParams = new URLSearchParams(window.location.search)
+    searchParams.set(LANG_QUERY_PARAM, language)
+    window.history.replaceState({}, '', `${window.location.pathname}?${searchParams.toString()}`)
+  }
+
   const handleChange = (event: any) => {
     i18n.changeLanguage(event.value)
     updateSelectedLanguage(event.value)
-
-    const searchParams = new URLSearchParams(window.location.search)
-    searchParams.set(LANG_QUERY_PARAM, event.value)
-    window.history.replaceState({}, '', `${window.location.pathname}?${searchParams.toString()}`)
+    setLangQueryParam(event.value)
   }
 
   const MAIN_COLOR = 'black'
@@ -32,11 +35,13 @@ const LanguageSelector = () => {
     return options
   }
 
-  const selectedLanguageToUse = (new URLSearchParams(window.location.search)).get(LANG_QUERY_PARAM) ?? selectedLanguage ?? 'en'
+  const langParam = (new URLSearchParams(window.location.search)).get(LANG_QUERY_PARAM) ?? ''
+  const selectedLanguageToUse = Object.keys(locales).includes(langParam) ? langParam : selectedLanguage ?? 'en'
 
   useEffect(() => {
     if (selectedLanguage){
       i18n.changeLanguage(selectedLanguage)
+      setLangQueryParam(selectedLanguage)
     }
   }, [i18n, selectedLanguage])
 

--- a/src/components/landing/LatestRecords.tsx
+++ b/src/components/landing/LatestRecords.tsx
@@ -9,10 +9,10 @@ import { PrimaryButton } from '../Button'
 import { Trans, useTranslation } from 'react-i18next'
 import LatestContributionsBorder from '../../assets/latest-contributions-border.svg'
 import { providers, utils } from 'ethers'
-import { INFURA_ID } from '../../constants'
+import { INFURA_ID, LANG_QUERY_PARAM } from '../../constants'
 
 const LatestRecords = () => {
-    useTranslation()
+    const { i18n: { language } } = useTranslation()
     const [isLoading, setIsLoading] = useState(true)
     const [formattedData, setFormattedData] = useState<Record[]>([])
     // load data from API
@@ -22,7 +22,7 @@ const LatestRecords = () => {
     const provider = new providers.InfuraProvider('homestead', INFURA_ID)
 
     const onClickViewContributions = () => {
-      window.open(window.location.origin + '/#' + ROUTES.RECORD)
+      window.open( `${window.location.origin}/?${LANG_QUERY_PARAM}=${language}#${ROUTES.RECORD}`)
     }
 
     useEffect(() => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
-const CIRCLE_SIZE = 490;
+const CIRCLE_SIZE = 490
 
-const PAGE_SIZE = 20;
+const PAGE_SIZE = 20
 
 const FONT_SIZE = {
   XXS: '9px',
@@ -52,9 +52,15 @@ const START_DATE =
 const END_DATE =
   parseInt(process.env.REACT_APP_END_DATE as string) || 1678713180
 
-const INFURA_ID = process.env.REACT_APP_INFURA_ID || 'cd82571d19ab490e828dd0f86ec3cbf0'
-const PORTIS_ID = process.env.REACT_APP_PORTIS_ID || 'd6418a0a-18ae-4dfd-a206-3398012907ec'
-const FORTMATIC_KEY = process.env.REACT_APP_FORTMATIC_KEY || 'pk_live_AAE763E3E8AC097E'
+const INFURA_ID =
+  process.env.REACT_APP_INFURA_ID || 'cd82571d19ab490e828dd0f86ec3cbf0'
+const PORTIS_ID =
+  process.env.REACT_APP_PORTIS_ID || 'd6418a0a-18ae-4dfd-a206-3398012907ec'
+const FORTMATIC_KEY =
+  process.env.REACT_APP_FORTMATIC_KEY || 'pk_live_AAE763E3E8AC097E'
+
+const LANG_QUERY_PARAM = 'lang'
+const DEFAULT_LANG = 'en'
 
 export {
   FONT_SIZE,
@@ -74,4 +80,6 @@ export {
   PORTIS_ID,
   FORTMATIC_KEY,
   INFURA_ID,
+  LANG_QUERY_PARAM,
+  DEFAULT_LANG
 }

--- a/src/hooks/useLanguage.ts
+++ b/src/hooks/useLanguage.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { LANG_QUERY_PARAM, DEFAULT_LANG } from '../constants'
+
+export default function useLanguage() {
+  const { i18n } = useTranslation()
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const lang: string = params.get(LANG_QUERY_PARAM) || DEFAULT_LANG
+    i18n.changeLanguage(lang)
+  }, [i18n])
+}

--- a/src/hooks/useQueryParamLanguage.ts
+++ b/src/hooks/useQueryParamLanguage.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { LANG_QUERY_PARAM, DEFAULT_LANG } from '../constants'
 
-export default function useLanguage() {
+export default function useQueryParamLanguage() {
   const { i18n } = useTranslation()
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)

--- a/src/pages/complete.tsx
+++ b/src/pages/complete.tsx
@@ -19,10 +19,10 @@ import {
   Over,
 } from '../components/Layout'
 import ShareSocialModal from '../components/modals/ShareSocialModal'
-import useLanguage from '../hooks/useLanguage'
+import useQueryParamLanguage from '../hooks/useQueryParamLanguage'
 
 const CompletePage = () => {
-  useLanguage()
+  useQueryParamLanguage()
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [error, setError] = useState<null | string>(null)

--- a/src/pages/complete.tsx
+++ b/src/pages/complete.tsx
@@ -19,8 +19,10 @@ import {
   Over,
 } from '../components/Layout'
 import ShareSocialModal from '../components/modals/ShareSocialModal'
+import useLanguage from '../hooks/useLanguage'
 
 const CompletePage = () => {
+  useLanguage()
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [error, setError] = useState<null | string>(null)

--- a/src/pages/contributing.tsx
+++ b/src/pages/contributing.tsx
@@ -21,10 +21,12 @@ import {
   TextSection,
   InnerWrap
 } from '../components/Layout'
+import useLanguage from '../hooks/useLanguage'
 
 type Steps = 'contributing' | 'completed' | 'error'
 
 const ContributingPage = () => {
+  useLanguage()
   const { sessionId, provider, nickname } = useAuthStore()
   const { entropy, ECDSASignature } = useEntropyStore()
   const {

--- a/src/pages/contributing.tsx
+++ b/src/pages/contributing.tsx
@@ -21,12 +21,12 @@ import {
   TextSection,
   InnerWrap
 } from '../components/Layout'
-import useLanguage from '../hooks/useLanguage'
+import useQueryParamLanguage from '../hooks/useQueryParamLanguage'
 
 type Steps = 'contributing' | 'completed' | 'error'
 
 const ContributingPage = () => {
-  useLanguage()
+  useQueryParamLanguage()
   const { sessionId, provider, nickname } = useAuthStore()
   const { entropy, ECDSASignature } = useEntropyStore()
   const {

--- a/src/pages/doubleSign.tsx
+++ b/src/pages/doubleSign.tsx
@@ -34,10 +34,10 @@ import Torus from '@toruslabs/torus-embed'
 import Fortmatic from 'fortmatic'
 import Portis from '@portis/web3'
 import api from '../api'
-import useLanguage from '../hooks/useLanguage'
+import useQueryParamLanguage from '../hooks/useQueryParamLanguage'
 
 const DoubleSignPage = () => {
-  useLanguage()
+  useQueryParamLanguage()
   const [error, setError] = useState<null | string>(null)
   const [isLoading, setIsLoading] = useState(false)
   const navigate = useNavigate()

--- a/src/pages/doubleSign.tsx
+++ b/src/pages/doubleSign.tsx
@@ -34,9 +34,10 @@ import Torus from '@toruslabs/torus-embed'
 import Fortmatic from 'fortmatic'
 import Portis from '@portis/web3'
 import api from '../api'
-
+import useLanguage from '../hooks/useLanguage'
 
 const DoubleSignPage = () => {
+  useLanguage()
   const [error, setError] = useState<null | string>(null)
   const [isLoading, setIsLoading] = useState(false)
   const navigate = useNavigate()

--- a/src/pages/entropyInput.tsx
+++ b/src/pages/entropyInput.tsx
@@ -28,6 +28,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { MIN_MOUSE_ENTROPY_SAMPLES, FONT_SIZE } from '../constants'
 import 'text-security'
 import LoadingSpinner from '../components/LoadingSpinner'
+import useLanguage from '../hooks/useLanguage'
 
 type Player = {
   play: () => void
@@ -36,6 +37,7 @@ type Player = {
 }
 
 const EntropyInputPage = () => {
+  useLanguage()
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [isLoading, setIsLoading] = useState(false)

--- a/src/pages/entropyInput.tsx
+++ b/src/pages/entropyInput.tsx
@@ -28,7 +28,7 @@ import { Trans, useTranslation } from 'react-i18next'
 import { MIN_MOUSE_ENTROPY_SAMPLES, FONT_SIZE } from '../constants'
 import 'text-security'
 import LoadingSpinner from '../components/LoadingSpinner'
-import useLanguage from '../hooks/useLanguage'
+import useQueryParamLanguage from '../hooks/useQueryParamLanguage'
 
 type Player = {
   play: () => void
@@ -37,7 +37,7 @@ type Player = {
 }
 
 const EntropyInputPage = () => {
-  useLanguage()
+  useQueryParamLanguage()
   const { t } = useTranslation()
   const navigate = useNavigate()
   const [isLoading, setIsLoading] = useState(false)

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -18,8 +18,10 @@ import LatestRecords from '../components/landing/LatestRecords'
 import OtherResources from '../components/landing/OtherResources'
 import { PrimaryButton } from '../components/Button'
 import LatestContributionsBorder from '../assets/latest-contributions-border.svg'
+import useLanguage from '../hooks/useLanguage'
 
 const LandingPage = () => {
+  useLanguage()
   const { i18n: { language } } = useTranslation()
   const ref = useRef<null | HTMLElement>(null)
   const navigate = useNavigate()

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -18,10 +18,10 @@ import LatestRecords from '../components/landing/LatestRecords'
 import OtherResources from '../components/landing/OtherResources'
 import { PrimaryButton } from '../components/Button'
 import LatestContributionsBorder from '../assets/latest-contributions-border.svg'
-import useLanguage from '../hooks/useLanguage'
+import useQueryParamLanguage from '../hooks/useQueryParamLanguage'
 
 const LandingPage = () => {
-  useLanguage()
+  useQueryParamLanguage()
   const { i18n: { language } } = useTranslation()
   const ref = useRef<null | HTMLElement>(null)
   const navigate = useNavigate()

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -10,7 +10,7 @@ import useCountdown from '../hooks/useCountdown'
 import Header from '../components/headers/Header'
 import { TextSection } from '../components/Layout'
 import { Trans, useTranslation } from 'react-i18next'
-import { CIRCLE_SIZE, END_DATE, ENVIRONMENT } from '../constants'
+import { CIRCLE_SIZE, END_DATE, ENVIRONMENT, LANG_QUERY_PARAM } from '../constants'
 import { Description, ItalicSubTitle, PageTitle } from '../components/Text'
 import Explanation from '../components/landing/Explanation'
 import { BgColoredContainer } from '../components/Background'
@@ -20,7 +20,7 @@ import { PrimaryButton } from '../components/Button'
 import LatestContributionsBorder from '../assets/latest-contributions-border.svg'
 
 const LandingPage = () => {
-  useTranslation()
+  const { i18n: { language } } = useTranslation()
   const ref = useRef<null | HTMLElement>(null)
   const navigate = useNavigate()
   const { signout } = useAuthStore()
@@ -42,7 +42,7 @@ const LandingPage = () => {
   }, [])
 
   const onClickBegin = () => {
-    window.open(window.location.origin + '/#' + ROUTES.ENTROPY_INPUT)
+    window.open(`${window.location.origin}/?${LANG_QUERY_PARAM}=${language}#${ROUTES.ENTROPY_INPUT}`)
 }
 
   return (

--- a/src/pages/lobby.tsx
+++ b/src/pages/lobby.tsx
@@ -19,10 +19,10 @@ import HeaderJustGoingBack from '../components/headers/HeaderJustGoingBack'
 import useSequencerStatus from '../hooks/useSequencerStatus'
 import { Trans, useTranslation } from 'react-i18next'
 import { ErrorRes } from '../types'
-import useLanguage from '../hooks/useLanguage'
+import useQueryParamLanguage from '../hooks/useQueryParamLanguage'
 
 const LobbyPage = () => {
-  useLanguage()
+  useQueryParamLanguage()
   const { t } = useTranslation()
   const { error, setError } = useAuthStore()
   const [showError, setShowError] = useState(error)

--- a/src/pages/lobby.tsx
+++ b/src/pages/lobby.tsx
@@ -19,8 +19,10 @@ import HeaderJustGoingBack from '../components/headers/HeaderJustGoingBack'
 import useSequencerStatus from '../hooks/useSequencerStatus'
 import { Trans, useTranslation } from 'react-i18next'
 import { ErrorRes } from '../types'
+import useLanguage from '../hooks/useLanguage'
 
 const LobbyPage = () => {
+  useLanguage()
   const { t } = useTranslation()
   const { error, setError } = useAuthStore()
   const [showError, setShowError] = useState(error)

--- a/src/pages/lobbyFull.tsx
+++ b/src/pages/lobbyFull.tsx
@@ -13,8 +13,10 @@ import {
   Over,
 } from '../components/Layout'
 import ROUTES from '../routes'
+import useLanguage from '../hooks/useLanguage'
 
 const LobbyFullPage = () => {
+  useLanguage()
   useTranslation()
   const navigate = useNavigate()
 

--- a/src/pages/lobbyFull.tsx
+++ b/src/pages/lobbyFull.tsx
@@ -13,10 +13,10 @@ import {
   Over,
 } from '../components/Layout'
 import ROUTES from '../routes'
-import useLanguage from '../hooks/useLanguage'
+import useQueryParamLanguage from '../hooks/useQueryParamLanguage'
 
 const LobbyFullPage = () => {
-  useLanguage()
+  useQueryParamLanguage()
   useTranslation()
   const navigate = useNavigate()
 

--- a/src/pages/record.tsx
+++ b/src/pages/record.tsx
@@ -10,6 +10,7 @@ import Header from '../components/headers/Header'
 import Pagination from '../components/Pagination'
 import RecordTable from '../components/RecordTable'
 import ExternalLink from '../components/ExternalLink'
+import { BgColoredContainer } from '../components/Background'
 // Constant imports
 import { API_ROOT, BREAKPOINT, FONT_SIZE, INFURA_ID, PAGE_SIZE } from '../constants'
 import { Transcript, Record, SequencerStatus } from '../types'
@@ -18,11 +19,11 @@ import SearchIcon from '../assets/search.svg'
 // Hook imports
 import useRecord from '../hooks/useRecord'
 import useSequencerStatus from '../hooks/useSequencerStatus'
-import { BgColoredContainer } from '../components/Background'
-
+import useLanguage from '../hooks/useLanguage'
 
 // RecordPage component
 const RecordPage = () => {
+  useLanguage()
   const { t } = useTranslation()
   const [page, setPage] = useState(1)
   const [totalPages, setTotalPages] = useState(0)

--- a/src/pages/record.tsx
+++ b/src/pages/record.tsx
@@ -19,11 +19,11 @@ import SearchIcon from '../assets/search.svg'
 // Hook imports
 import useRecord from '../hooks/useRecord'
 import useSequencerStatus from '../hooks/useSequencerStatus'
-import useLanguage from '../hooks/useLanguage'
+import useQueryParamLanguage from '../hooks/useQueryParamLanguage'
 
 // RecordPage component
 const RecordPage = () => {
-  useLanguage()
+  useQueryParamLanguage()
   const { t } = useTranslation()
   const [page, setPage] = useState(1)
   const [totalPages, setTotalPages] = useState(0)

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -19,8 +19,10 @@ import { Trans, useTranslation } from 'react-i18next'
 import HeaderJustGoingBack from '../components/headers/HeaderJustGoingBack'
 import api from '../api'
 import LoadingSpinner from '../components/LoadingSpinner'
+import useLanguage from '../hooks/useLanguage'
 
 const SigninPage = () => {
+  useLanguage()
   useTranslation()
   const navigate = useNavigate()
   const { error } = useAuthStore()

--- a/src/pages/signin.tsx
+++ b/src/pages/signin.tsx
@@ -19,10 +19,10 @@ import { Trans, useTranslation } from 'react-i18next'
 import HeaderJustGoingBack from '../components/headers/HeaderJustGoingBack'
 import api from '../api'
 import LoadingSpinner from '../components/LoadingSpinner'
-import useLanguage from '../hooks/useLanguage'
+import useQueryParamLanguage from '../hooks/useQueryParamLanguage'
 
 const SigninPage = () => {
-  useLanguage()
+  useQueryParamLanguage()
   useTranslation()
   const navigate = useNavigate()
   const { error } = useAuthStore()

--- a/src/pages/signinRedirect.tsx
+++ b/src/pages/signinRedirect.tsx
@@ -5,8 +5,10 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { useEntropyStore } from '../store/contribute'
 import { toParams, validateSigninParams } from '../utils'
+import useLanguage from '../hooks/useLanguage'
 
 const SigninRedirect = (props: any) => {
+  useLanguage()
   const navigate = useNavigate()
   const { t } = useTranslation()
   const { ECDSASigner } = useEntropyStore()

--- a/src/pages/signinRedirect.tsx
+++ b/src/pages/signinRedirect.tsx
@@ -5,10 +5,10 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { useEntropyStore } from '../store/contribute'
 import { toParams, validateSigninParams } from '../utils'
-import useLanguage from '../hooks/useLanguage'
+import useQueryParamLanguage from '../hooks/useQueryParamLanguage'
 
 const SigninRedirect = (props: any) => {
-  useLanguage()
+  useQueryParamLanguage()
   const navigate = useNavigate()
   const { t } = useTranslation()
   const { ECDSASigner } = useEntropyStore()


### PR DESCRIPTION
## Description
Recently the ceremony and contributions pages were updated to open in new tabs. With this, the language selection from the landing page was lost, and the new pages opened with English even if the user changed languages. 

## Approach to fixing in this PR
- Passes a simple query parameter when the Ceremony flow and Contributions (`/record`) pages are opened, by injected `?lang=${language}` before the hash link in the path.
- Added a `useQueryParamLanguage` hook that checks for this query parameter and sets the i18next language to this language, defaulting to English if none provided.
- Added this hook to landing page, and all pages in the Ceremony flow, and also the `records` page
- Updated `LanguageSelector` to use query param language as priority if provided, and to update the `lang` query param any time the language is updated so this persist on refresh. 
- Allows passing a language along with the URL using `?lang=` syntax
- Adds lang query param on page load for consistency

## Screenshots
<img width="1224" alt="image" src="https://user-images.githubusercontent.com/54227730/212231990-6201755c-6f00-489b-9d5d-620002952724.png">
