### PR TITLE
Add RTL support for Arabic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { HashRouter, Routes, Route } from 'react-router-dom'
 import {
   HomePage,
@@ -16,6 +17,7 @@ import RequireAuth from './components/helper/RequireAuth'
 import usePreloadAllImages from './hooks/usePreloadAllImages'
 import ROUTES from './routes'
 import GlobalStyle from './style/global'
+import { useTranslation } from 'react-i18next'
 
 function App() {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -26,6 +28,11 @@ function App() {
   const message = params.get('message')
   const code = params.get("code")
   const isRedirect = (sessionId !== null || message !== null || code !== null)
+
+  // Handle RTL text direction for Arabic language
+  const { i18n: { language } } = useTranslation()
+  const dir = useMemo(() => language === 'ar' ? 'rtl' : 'ltr', [language])
+  document.getElementsByTagName('html')[0].setAttribute("dir", dir);
 
   /* Considerations for the IPFS build:
     - IPFS gateways comsider anything after the / a path to a folder. So our preferred method

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect } from 'react'
 import { HashRouter, Routes, Route } from 'react-router-dom'
 import {
   HomePage,
@@ -31,8 +31,10 @@ function App() {
 
   // Handle RTL text direction for Arabic language
   const { i18n: { language } } = useTranslation()
-  const dir = useMemo(() => language === 'ar' ? 'rtl' : 'ltr', [language])
-  document.getElementsByTagName('html')[0].setAttribute("dir", dir);
+  useEffect(() => {
+    const dir = language === 'ar' ? 'rtl' : 'ltr'
+    document.getElementsByTagName('html')[0].setAttribute("dir", dir);
+  }, [language])
 
   /* Considerations for the IPFS build:
     - IPFS gateways comsider anything after the / a path to a folder. So our preferred method

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,11 +29,12 @@ function App() {
   const code = params.get("code")
   const isRedirect = (sessionId !== null || message !== null || code !== null)
 
-  // Handle RTL text direction for Arabic language
+  // Handle RTL text direction for Arabic language and update the lang attribute
   const { i18n: { language } } = useTranslation()
   useEffect(() => {
     const dir = language === 'ar' ? 'rtl' : 'ltr'
     document.getElementsByTagName('html')[0].setAttribute("dir", dir);
+    document.getElementsByTagName('html')[0].setAttribute("lang", language.slice(-2));
   }, [language])
 
   /* Considerations for the IPFS build:


### PR DESCRIPTION
## Description
- Checks selected language and applies `dir="rtl"` to `html` tag when Arabic is chosen for a right-to-left layout
- Updates the `lang` attribute for the `html` tag as well

## Screenshots
<img width="1268" alt="image" src="https://user-images.githubusercontent.com/54227730/212752063-c87cd18c-5250-425a-ae1d-1f09da5b1654.png">
<img width="689" alt="image" src="https://user-images.githubusercontent.com/54227730/212752098-2ea36a3f-eb64-4630-b3ec-1a15365463ce.png">
(Translated string updates found in #146, screenshots intended to demonstrate the RTL layout)