### PR TITLE
Nico fix rate limit lobby

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -70,28 +70,43 @@ class APIClient {
     identity: string,
     signature: string | null
   ): Promise<ErrorRes | ContributeRes> {
-    let contribution  = await wasm.contribute(preContribution, entropy, identity)
-    useEntropyStore.persist.clearStorage()
-    let contributionObj = null
-    if (signature) {
-      contributionObj = JSON.parse(contribution!)
-      contributionObj.ecdsaSignature = signature
-      contributionObj = JSON.stringify(contributionObj)
-      contribution = contributionObj
+    let contribution = null
+    try {
+      contribution  = await wasm.contribute(preContribution, entropy, identity)
+      useEntropyStore.persist.clearStorage()
+      let contributionObj = null
+      if (signature) {
+        contributionObj = JSON.parse(contribution!)
+        contributionObj.ecdsaSignature = signature
+        contributionObj = JSON.stringify(contributionObj)
+        contribution = contributionObj
+      }
+    } catch (error: any) {
+      return {
+        code: error.name,
+        error: error.message
+      }
     }
-
-    const res = await fetch(`${API_ROOT}/contribute`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${session_id}`
-      },
-      body: contribution
-    })
-    return {
-      ...(await res.json()),
-      contribution
-    } as ContributeRes
+    try {
+      const res = await fetch(`${API_ROOT}/contribute`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session_id}`
+        },
+        body: contribution
+      })
+      console.log('after fetch')
+      return {
+        ...(await res.json()),
+        contribution
+      } as ContributeRes
+    } catch (error: any) {
+      return {
+        code: error.name,
+        error: error.message
+      }
+    }
   }
 }
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -46,14 +46,21 @@ class APIClient {
   async tryContribute(
     session_id: string
   ): Promise<ErrorRes | TryContributeRes> {
-    const res = await fetch(`${API_ROOT}/lobby/try_contribute`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${session_id}`
+    try {
+      const res = await fetch(`${API_ROOT}/lobby/try_contribute`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session_id}`
+        }
+      })
+      return await res.json()
+    } catch (error: any) {
+      return {
+        code: error.name,
+        error: error.message
       }
-    })
-    return await res.json()
+    }
   }
 
   async contribute(

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -242,6 +242,7 @@
         "rateLimited": "The call to the sequencer came too early. This is only a warning, keep this tab open waiting for your turn and if needed submit an issue in Github",
         "unknownSessionId": "Unknown user. The lobby had a problem. Please sign in and try again",
         "anotherContributionInProgress": "There is another contribution being computed at the moment. Please wait for your turn to contribute",
+        "typeError": "Temporary network issues. Attempting to reconnect",
         "unknownError": "There has been an unknown error: {{error}} . code: {{code}}"
       },
       "authErrorPayload": {

--- a/src/pages/lobby.tsx
+++ b/src/pages/lobby.tsx
@@ -58,14 +58,18 @@ const LobbyPage = () => {
               setError( t('error.tryContributeError.unknownSessionId') )
               console.log(resError.error)
               navigate(ROUTES.SIGNIN)
-              break
+              return
             case 'TryContributeError::AnotherContributionInProgress':
               console.log(resError.error)
               break
             case 'TryContributeError::LobbyIsFull':
               console.log(resError.error)
               navigate(ROUTES.LOBBY_FULL)
-              break
+              return
+            case 'TypeError':
+              setShowError( t('error.tryContributeError.typeError'))
+              console.log(resError.error)
+              break;
             default:
               // StorageError and TaskError keep you in the lobby until sequencer gets fixed
               setShowError( t('error.tryContributeError.unknownError', resError) )
@@ -74,6 +78,7 @@ const LobbyPage = () => {
           }
           //  try again after LOBBY_CHECKIN_FREUQUENCY
           await sleep(LOBBY_CHECKIN_FREQUENCY)
+          setShowError(null)
         }
       }
     }


### PR DESCRIPTION
1. catch network error when lobby is pinging the sequencer (in case there is a sequencer crash or a Nginx rate limiting feature)
2. catch wasm error when contribute so participants explicitly knows that some when wrong (this should not happen but we should handle this situation just in case)
3. catch network when uploading contribution to sequencer (in case there is a sequencer crash or a Nginx rate limiting feature)

This branch is already merged with the `staging` branch so you can check it out in our deploy site