### PR TITLE
fix: link to kzg-ceremony-sequencer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This React App is a graphic interface to interact with the [Ethereum KZG Ceremon
 
 To start this app execute the following steps:
 
-1. Run the sequencer app from [https://github.com/ethereum/kzg-ceremony-sequencer](). It is assumed that the assigned port is 3000 and that our react app would use port 3001. You can set `PORT` env variable with a specific port for React.
+1. Run the sequencer app from [https://github.com/ethereum/kzg-ceremony-sequencer](https://github.com/ethereum/kzg-ceremony-sequencer). It is assumed that the assigned port is 3000 and that our react app would use port 3001. You can set `PORT` env variable with a specific port for React.
 
 2. Setup environment variables:
 


### PR DESCRIPTION
When you click on the link to https://github.com/ethereum/kzg-ceremony-sequencer in README.md, it redirects to https://github.com/zkparty/trusted-setup-frontend/tree/main. Therefore, I have updated the link.